### PR TITLE
feat: allow extra upstream headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Ask *"what's trending in crypto right now?"* to confirm it works.
 | `ELFA_TIMEOUT` | no | Request timeout in ms, default `120000` |
 | `ELFA_RETRIES` | no | Retries on failure, default `0` |
 | `ELFA_MCP_MAX_RESPONSE_CHARS` | no | Response size ceiling, default `60000` |
+| `ELFA_EXTRA_HEADERS` | no | JSON object of extra headers to send upstream, for proxies and non-production environments |
 
 The timeout is high and retries are off on purpose. The interpretation endpoints are LLM-backed and can take over a minute, and they cost credits per attempt, so a silent retry would bill you again for a call you never saw. Raise `ELFA_RETRIES` only if you are calling the cheap measurement endpoints.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,6 +32,7 @@ export function buildDeps(
     retries: config.retries,
     ...(hmacSecret ? { hmacSecret } : {}),
     ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    ...(config.extraHeaders ? { headers: config.extraHeaders } : {}),
   });
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface ServerConfig {
   apiKey: string | undefined;
   hmacSecret: string | undefined;
   baseUrl: string | undefined;
+  extraHeaders: Record<string, string> | undefined;
   timeout: number;
   retries: number;
   maxResponseChars: number;
@@ -19,6 +20,8 @@ const DEFAULT_TIMEOUT = 120000;
 const DEFAULT_RETRIES = 0;
 const DEFAULT_MAX_RESPONSE_CHARS = 60000;
 
+const RESERVED = new Set(["x-elfa-api-key", "x-elfa-signature", "x-elfa-timestamp"]);
+
 function num(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
   const parsed = Number(value);
@@ -29,6 +32,25 @@ function count(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function headers(value: string | undefined): Record<string, string> | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const out: Record<string, string> = {};
+    for (const [key, entry] of Object.entries(parsed)) {
+      if (typeof entry === "string" && !RESERVED.has(key.toLowerCase())) {
+        out[key] = entry;
+      }
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function list(value: string | undefined): string[] {
@@ -51,6 +73,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     apiKey: env.ELFA_API_KEY || undefined,
     hmacSecret: env.ELFA_HMAC_SECRET || undefined,
     baseUrl: env.ELFA_BASE_URL || undefined,
+    extraHeaders: headers(env.ELFA_EXTRA_HEADERS),
     timeout: num(env.ELFA_TIMEOUT, DEFAULT_TIMEOUT),
     retries: count(env.ELFA_RETRIES, DEFAULT_RETRIES),
     maxResponseChars: num(

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -206,3 +206,25 @@ describe("mentions without an author", () => {
     expect(shaped.verified).toBe(true);
   });
 });
+
+describe("extra headers", () => {
+  it("parses a JSON object of headers", () => {
+    expect(loadConfig({ ELFA_EXTRA_HEADERS: '{"X-Trace":"abc"}' }).extraHeaders).toEqual({
+      "X-Trace": "abc",
+    });
+  });
+
+  it("refuses to let a caller override authentication headers", () => {
+    expect(
+      loadConfig({
+        ELFA_EXTRA_HEADERS: '{"x-elfa-api-key":"stolen","X-Elfa-Signature":"forged","X-Ok":"1"}',
+      }).extraHeaders,
+    ).toEqual({ "X-Ok": "1" });
+  });
+
+  it("ignores malformed or non-object values", () => {
+    for (const value of ["not json", "[1,2]", '"a string"', "{}", '{"a":1}']) {
+      expect(loadConfig({ ELFA_EXTRA_HEADERS: value }).extraHeaders, value).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Adds `ELFA_EXTRA_HEADERS`, a JSON object of headers sent on every upstream request.

## Why

Two concrete needs, both already in front of us:

- **Testing against non-production environments.** Staging sits behind a gate that requires an extra header. Without this the server can only ever be pointed at production, so nothing can be verified before release.
- **The eval harness.** The `mcp` mode added in elfa-ai/elfa-docs needs to reach the same environment the other modes reach, which means sending the same bypass header they send.

It is also the ordinary answer for anyone running the server behind a proxy that expects an identifying header.

## Safety

Authentication headers cannot be overridden. `x-elfa-api-key`, `x-elfa-signature` and `x-elfa-timestamp` are dropped if present, so this cannot be used to smuggle in a different key or forge a signature. Malformed JSON, arrays, scalars and non-string values are ignored rather than throwing, so a bad value degrades to "no extra headers" instead of failing startup.

Values come from the environment only, never from a tool argument, so they stay out of model context.

## Testing

43 tests. New cases cover parsing, the auth-header override attempt, and every malformed shape.