### PR TITLE
ci: publish the registry entry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,41 @@ jobs:
       - name: Publish to NPM
         run: npm publish --access public
 
+  registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Wait for the package to be resolvable
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          for attempt in $(seq 1 30); do
+            if npm view "@elfa-ai/mcp@${VERSION}" version --prefer-online >/dev/null 2>&1; then
+              echo "npm has ${VERSION}"
+              exit 0
+            fi
+            echo "attempt ${attempt}: npm does not have ${VERSION} yet"
+            sleep 10
+          done
+          echo "npm never served ${VERSION}; the registry verifies ownership against it, so stopping"
+          exit 1
+
+      - name: Publish to the registry
+        run: |
+          ./mcp-publisher login dns --domain elfa.ai --private-key "$MCP_PRIVATE_KEY"
+          ./mcp-publisher publish
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
The registry entry for `ai.elfa/mcp` was published by hand. This makes the release workflow do it, so it cannot go stale.

## The problem

npm and the GitHub release update on every tag. The registry does not. It currently pins 2.0.0, so the moment 2.0.1 ships the registry advertises a version that is no longer current — silently, with nothing red anywhere.

That is the same rot that left this repo on a retired API for a year.

## The job

Runs after `publish`, in parallel with `create-release`:

1. Installs `mcp-publisher`
2. **Waits for npm to actually serve the new version**, polling for up to five minutes
3. Logs in with DNS auth and publishes

Step 2 matters. The registry verifies ownership by fetching the package and checking its `mcpName`, so publishing before npm's CDN has the version fails. Ten seconds between attempts, and it exits non-zero rather than publishing against a version that is not there.

## Auth

DNS ownership of `elfa.ai`, proved by a TXT record holding an Ed25519 public key. The private key is stored as the `MCP_PRIVATE_KEY` repository secret.

Worth knowing: nothing else holds a copy of that key. If it is lost the TXT record has to be replaced with a fresh one before the registry will accept a publish again. It should be backed up wherever the team keeps shared secrets.

## Failure behaviour

The registry job is deliberately independent of `create-release`. If the registry is down or rejects the publish, npm and the GitHub release still complete — only the registry listing is delayed, and re-running the single job fixes it without re-tagging.
