### PR TITLE
chore: release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.0.0
+
+### Removed
+
+- **The `auto_exchanges` tool is gone.** Exchange connections are no longer part of the documented Auto surface, so listing, connecting and disconnecting venues is no longer exposed here. The three operations are recorded in `manifest.json` under `unexposed`, so the drift check still accounts for every documented `/v2` operation. The endpoints remain reachable over the API for anyone who needs them.
+
+### Changed
+
+- **`validate_symbol` moved to `auto_validate`.** It is now `auto_validate` with `method=symbol`, taking `exchange` and `symbol`, and returns `valid: true/false` with the unsupported case reported as a validation error. The default `method=query` behaviour is unchanged.
+- **Eleven tools**, down from twelve.
+- Signing guidance everywhere — server instructions, `auto_query_write`, README, install docs, the desktop bundle and the registry entry — now describes `ELFA_HMAC_SECRET` as signing Auto mutations that are not plain notifications, rather than exchange linking and order placement.
+
 ## 2.0.0
 
 ### Changed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,8 +101,8 @@ If a call fails, `api_status` reports whether the key is valid and how many cred
 | Server does not appear | Node is older than 20, or the client was not restarted |
 | Authentication failed | `ELFA_API_KEY` is missing, wrong, or expired |
 | Out of credits | The plan's monthly credits are used up |
-| Action requires request signing | `ELFA_HMAC_SECRET` is not set, and the request links an exchange or places an order |
-| Forbidden on an Auto trading call | Auto has not been enabled for the account in the developer portal |
+| Action requires request signing | `ELFA_HMAC_SECRET` is not set, and the mutation is not a plain notification |
+| Forbidden on an Auto call | Auto has not been enabled for the account in the developer portal |
 | Timestamp too far from server time | The machine's clock has drifted. Signed requests are rejected beyond 30 seconds |
 
 Claude Desktop logs are in `~/Library/Logs/Claude/mcp*.log` on macOS and `%APPDATA%\Claude\logs\mcp*.log` on Windows.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "server": {
     "name": "elfa",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "docs": "https://docs.elfa.ai",
     "spec": "https://docs.elfa.ai/swagger/swagger.json",
     "specScope": "/v2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfa-ai/mcp",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Model Context Protocol server for the Elfa API - crypto social intelligence and the Auto condition engine",
   "license": "MIT",
   "author": "Elfa AI",

--- a/scripts/build-bundle.ts
+++ b/scripts/build-bundle.ts
@@ -83,7 +83,7 @@ const bundle = {
       type: "string",
       title: "Signing secret",
       description:
-        "Optional. Needed only to connect an exchange or run an Auto query that places an order.",
+        "Optional. Signs Auto mutations that are not plain notifications.",
       sensitive: true,
       required: false,
     },

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.elfa/mcp",
   "description": "Crypto social intelligence from X and Telegram, plus the Elfa Auto condition engine",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "repository": {
     "url": "https://github.com/elfa-ai/mcp",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@elfa-ai/mcp",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {
@@ -24,7 +24,7 @@
         },
         {
           "name": "ELFA_HMAC_SECRET",
-          "description": "Signs Auto requests that link an exchange or place an order",
+          "description": "Signs Auto mutations that are not plain notifications",
           "isRequired": false,
           "isSecret": true
         }


### PR DESCRIPTION
Release prep for `3.0.0`, plus three copy fixes the previous sync missed.

## Version

`2.0.0` → `3.0.0` across `package.json`, `manifest.json` and `server.json` (both the server version and the npm package entry). `check:drift` enforces those staying equal. Major, because #18 removed the `auto_exchanges` tool and moved `validate_symbol` under `auto_validate`.

`CHANGELOG.md` gets the matching `## 3.0.0` section, which the release workflow reads for the GitHub release notes.

## Copy fixes

Three places still described `ELFA_HMAC_SECRET` in terms of exchange linking and order placement. All three ship to users, so they matter more than a README line:

| File | Where it surfaces |
| --- | --- |
| `server.json` | the MCP registry entry |
| `scripts/build-bundle.ts` | the Claude Desktop `.mcpb` config prompt |
| `docs/installation.md` | the troubleshooting table |

All now say the secret signs Auto mutations that are not plain notifications. The troubleshooting row "Forbidden on an Auto trading call" becomes "Forbidden on an Auto call" for the same reason.

## Verification

- `npm run verify` — typecheck, 43 tests, `check:drift` (36 documented operations across 11 tools, 6 deliberately unexposed), `docs:check`: all pass.
- `npm run build:bundle` produces `elfa-mcp-3.0.0.mcpb`.

## After merge

Tagging `v3.0.0` runs the release workflow: npm publish via trusted publishing, MCP registry publish, and a GitHub release carrying the `.mcpb`. The workflow fails fast if the tag and `package.json` disagree, so the tag must be exactly `v3.0.0`.
